### PR TITLE
Swap 'urlencode' for 'rawurlencode' to prevent test failure

### DIFF
--- a/tests/src/Provider/ZendeskTest.php
+++ b/tests/src/Provider/ZendeskTest.php
@@ -82,7 +82,7 @@ class ZendeskTest extends \PHPUnit_Framework_TestCase
 
         $url = $this->provider->getAuthorizationUrl($options);
 
-        $this->assertContains(urlencode(implode(' ', $options['scope'])), $url);
+        $this->assertContains(rawurlencode(implode(' ', $options['scope'])), $url);
     }
 
     public function testGetAuthorizationUrl()

--- a/tests/src/Provider/ZendeskTest.php
+++ b/tests/src/Provider/ZendeskTest.php
@@ -82,7 +82,8 @@ class ZendeskTest extends \PHPUnit_Framework_TestCase
 
         $url = $this->provider->getAuthorizationUrl($options);
 
-        $this->assertContains(rawurlencode(implode(' ', $options['scope'])), $url);
+        $encodedScope = http_build_query(['scope' => implode(' ', $options['scope'])], null, '&', \PHP_QUERY_RFC3986);
+        $this->assertContains($encodedScope, $url);
     }
 
     public function testGetAuthorizationUrl()


### PR DESCRIPTION
I noticed this one while testing pull request #2. While running the tests I received this failure:

```
There was 1 failure:

1) Stevenmaguire\OAuth2\Client\Test\Provider\ZendeskTest::testScopes
Failed asserting that 'https://58ac3f8a24995.zendesk.com/oauth/authorizations/new?scope=58ac3f8a249ea%2058ac3f8a249f0&state=50ccf66046c5ea48a6c6e9497633258e&response_type=code&approval_prompt=auto&redirect_uri=none&client_id=mock_client_id' contains "58ac3f8a249ea+58ac3f8a249f0".

oauth2-zendesk/tests/src/Provider/ZendeskTest.php:85
```

This error is due to different encoding schemes being used in the test and the underlying oauth2-client package. _urlencode_ changes spaces to '+', _rawurlencode_ changes spaces to '%20'.

I believe in the league/oauth2-client package the QueryBuilderTrait switched from '\PHP_QUERY_RFC1738' (plus sign encoding for spaces) to '\PHP_QUERY_RFC3986' (percent encoding for spaces).

Example

Un-encoded:   58ac3fc62677f 58ac3fc6267a3
urlencode:    58ac3fc62677f+58ac3fc6267a3
rawurlencode: 58ac3fc62677f%2058ac3fc6267a3