### PR TITLE
Update resource owner accessors to account for deeper nesting in response

### DIFF
--- a/src/Provider/ZendeskResourceOwner.php
+++ b/src/Provider/ZendeskResourceOwner.php
@@ -31,7 +31,7 @@ class ZendeskResourceOwner implements ResourceOwnerInterface
      */
     public function getId()
     {
-        return $this->getResponseData('id');
+        return $this->getResponseData('user.id');
     }
 
     /**
@@ -41,7 +41,7 @@ class ZendeskResourceOwner implements ResourceOwnerInterface
      */
     public function getName()
     {
-        return $this->getResponseData('name');
+        return $this->getResponseData('user.name');
     }
 
     /**
@@ -51,7 +51,7 @@ class ZendeskResourceOwner implements ResourceOwnerInterface
      */
     public function getEmail()
     {
-        return $this->getResponseData('email');
+        return $this->getResponseData('user.email');
     }
 
     /**

--- a/tests/src/Provider/ZendeskTest.php
+++ b/tests/src/Provider/ZendeskTest.php
@@ -151,9 +151,9 @@ class ZendeskTest extends \PHPUnit_Framework_TestCase
         $user = $this->provider->getResourceOwner($token);
 
         $this->assertEquals($userData, $user->toArray());
-        $this->assertEquals($userData['id'], $user->getId());
-        $this->assertEquals($userData['name'], $user->getName());
-        $this->assertEquals($userData['email'], $user->getEmail());
+        $this->assertEquals($userData['user']['id'], $user->getId());
+        $this->assertEquals($userData['user']['name'], $user->getName());
+        $this->assertEquals($userData['user']['email'], $user->getEmail());
     }
 
     /**

--- a/tests/user_response.json
+++ b/tests/user_response.json
@@ -1,31 +1,33 @@
 {
-  "id":                    35436,
-  "url":                   "https://company.zendesk.com/api/v2/end_users/35436.json",
-  "name":                  "Johnny End User",
-  "created_at":            "2009-07-20T22:55:29Z",
-  "updated_at":            "2011-05-05T10:38:52Z",
-  "time_zone":             "Copenhagen",
-  "email":                 "johnny@example.com",
-  "phone":                 "555-123-4567",
-  "locale":                "en-US",
-  "locale_id":             1,
-  "organization_id":       57542,
-  "role":                  "end-user",
-  "verified":              true,
-  "photo": {
-    "id":           928374,
-    "name":         "my_funny_profile_pic.png",
-    "content_url":  "https://company.zendesk.com/photos/my_funny_profile_pic.png",
-    "content_type": "image/png",
-    "size":         166144,
-    "thumbnails": [
-      {
-        "id":           928375,
-        "name":         "my_funny_profile_pic_thumb.png",
-        "content_url":  "https://company.zendesk.com/photos/my_funny_profile_pic_thumb.png",
-        "content_type": "image/png",
-        "size":         58298
-      }
-    ]
-  }
+    "user": {
+        "id":                    35436,
+        "url":                   "https://company.zendesk.com/api/v2/end_users/35436.json",
+        "name":                  "Johnny End User",
+        "created_at":            "2009-07-20T22:55:29Z",
+        "updated_at":            "2011-05-05T10:38:52Z",
+        "time_zone":             "Copenhagen",
+        "email":                 "johnny@example.com",
+        "phone":                 "555-123-4567",
+        "locale":                "en-US",
+        "locale_id":             1,
+        "organization_id":       57542,
+        "role":                  "end-user",
+        "verified":              true,
+        "photo": {
+          "id":           928374,
+          "name":         "my_funny_profile_pic.png",
+          "content_url":  "https://company.zendesk.com/photos/my_funny_profile_pic.png",
+          "content_type": "image/png",
+          "size":         166144,
+          "thumbnails": [
+            {
+              "id":           928375,
+              "name":         "my_funny_profile_pic_thumb.png",
+              "content_url":  "https://company.zendesk.com/photos/my_funny_profile_pic_thumb.png",
+              "content_type": "image/png",
+              "size":         58298
+            }
+          ]
+        }
+    }
 }


### PR DESCRIPTION
The current ZendeskResourceOwner helper accessors (e.g. 'getId', 'getEmail') are expecting the user fields to be direct children of the main response object, but they appear to be contained in under a 'user' key.

Not sure if this is a change, but [the docs](https://developer.zendesk.com/rest_api/docs/core/users#show-the-currently-authenticated-user) have an example with the 'user' nesting.

Old structure:
```
{
  "id":   35436,
  "name": "Roger Wilco",
  ...
}
```
New structure:
```
{
  "user": {
    "id":   35436,
    "name": "Roger Wilco",
    ...
  }
}
```