### PR TITLE
add ability to pass in a scope instead of hardcoding

### DIFF
--- a/src/Provider/Zendesk.php
+++ b/src/Provider/Zendesk.php
@@ -12,6 +12,8 @@ class Zendesk extends AbstractProvider
 
     protected $subdomain;
 
+    protected $scopes = [];
+
     /**
      * @var string Key used in a token response to identify the resource owner.
      */
@@ -81,7 +83,24 @@ class Zendesk extends AbstractProvider
      */
     protected function getDefaultScopes()
     {
-        return [];
+        return $this->scopes;
+    }
+
+    /**
+     * Set the default scopes used by this provider.
+     *
+     * This should not be a complete list of all scopes, but the minimum
+     * required for the provider user interface!
+     *
+     * @return Zendesk
+     */
+    public function setDefaultScopes(Array $scopes)
+    {
+        if (!empty($scopes)) {
+            $this->scopes = $scopes;
+        }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
First off... thanks for this package! We use it to connect on behalf of multiple Zendesk users, which requires us to set different scopes when we instantiate the provider. This PR allows us to set the scope through a setDefaultScopes() method. Please consider, thanks!